### PR TITLE
add service package

### DIFF
--- a/service/collector/alert/alert.go
+++ b/service/collector/alert/alert.go
@@ -1,0 +1,110 @@
+package alert
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/opsgenie-exporter/service/collector/opsgenie"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	namespace = "opsgenie"
+	subsystem = "alert"
+
+	labelStatus = "status"
+)
+
+var (
+	alertCount *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "count"),
+		"Count of OpsGenie alerts.",
+		[]string{
+			labelStatus,
+		},
+		nil,
+	)
+)
+
+type Config struct {
+	Client *opsgenie.Client
+}
+
+type Alert struct {
+	client *opsgenie.Client
+}
+
+func New(config Config) (*Alert, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+
+	a := &Alert{
+		client: config.Client,
+	}
+
+	return a, nil
+}
+
+func (a *Alert) Collect(ch chan<- prometheus.Metric) error {
+	var g errgroup.Group
+
+	g.Go(func() error {
+		numAlerts, err := a.client.CountAlerts()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			alertCount,
+			prometheus.GaugeValue,
+			float64(numAlerts),
+			"",
+		)
+
+		return nil
+	})
+
+	g.Go(func() error {
+		numOpenAlerts, err := a.client.CountOpenAlerts()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			alertCount,
+			prometheus.GaugeValue,
+			float64(numOpenAlerts),
+			"open",
+		)
+
+		return nil
+	})
+
+	g.Go(func() error {
+		numClosedAlerts, err := a.client.CountClosedAlerts()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			alertCount,
+			prometheus.GaugeValue,
+			float64(numClosedAlerts),
+			"closed",
+		)
+
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (a *Alert) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- alertCount
+
+	return nil
+}

--- a/service/collector/alert/alert.go
+++ b/service/collector/alert/alert.go
@@ -2,9 +2,10 @@ package alert
 
 import (
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/opsgenie-exporter/service/collector/opsgenie"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/giantswarm/opsgenie-exporter/service/collector/opsgenie"
 )
 
 const (

--- a/service/collector/alert/error.go
+++ b/service/collector/alert/error.go
@@ -1,0 +1,14 @@
+package alert
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/collector/error.go
+++ b/service/collector/error.go
@@ -1,0 +1,14 @@
+package collector
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/collector/opsgenie/error.go
+++ b/service/collector/opsgenie/error.go
@@ -1,0 +1,14 @@
+package opsgenie
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/collector/opsgenie/opsgenie.go
+++ b/service/collector/opsgenie/opsgenie.go
@@ -1,0 +1,88 @@
+package opsgenie
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+)
+
+type Config struct {
+	Key string
+}
+
+type Client struct {
+	httpClient *http.Client
+}
+
+func New(config Config) (*Client, error) {
+	if config.Key == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Key must not be empty", config)
+	}
+
+	httpClient := &http.Client{
+		Transport: opsgenieTransport{
+			transport: http.DefaultTransport,
+			key:       config.Key,
+		},
+	}
+
+	c := &Client{
+		httpClient: httpClient,
+	}
+
+	return c, nil
+}
+
+func (c *Client) doCountRequest(query string) (int, error) {
+	type CountResponseData struct {
+		Count int `json:"count"`
+	}
+
+	type CountResponse struct {
+		Data CountResponseData `json:"data"`
+	}
+
+	url := "https://api.opsgenie.com/v2/alerts/count"
+
+	if query != "" {
+		url = fmt.Sprintf("%s?query=%s", url, query)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll((res.Body))
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	cr := CountResponse{}
+	if err := json.Unmarshal(body, &cr); err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return cr.Data.Count, nil
+}
+
+func (c *Client) CountAlerts() (int, error) {
+	return c.doCountRequest("")
+}
+
+func (c *Client) CountOpenAlerts() (int, error) {
+	return c.doCountRequest("status%3Aopen")
+}
+
+func (c *Client) CountClosedAlerts() (int, error) {
+	return c.doCountRequest("status%3Aclosed")
+}

--- a/service/collector/opsgenie/transport.go
+++ b/service/collector/opsgenie/transport.go
@@ -1,0 +1,16 @@
+package opsgenie
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type opsgenieTransport struct {
+	transport http.RoundTripper
+	key       string
+}
+
+func (t opsgenieTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", fmt.Sprintf("GenieKey %s", t.key))
+	return t.transport.RoundTrip(r)
+}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -1,0 +1,74 @@
+package collector
+
+import (
+	"github.com/giantswarm/exporterkit/collector"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/viper"
+
+	"github.com/giantswarm/opsgenie-exporter/flag"
+	"github.com/giantswarm/opsgenie-exporter/service/collector/alert"
+	"github.com/giantswarm/opsgenie-exporter/service/collector/opsgenie"
+)
+
+type SetConfig struct {
+	Flag   *flag.Flag
+	Logger micrologger.Logger
+	Viper  *viper.Viper
+}
+
+// Set is basically only a wrapper for the operator's collector implementations.
+// It eases the iniitialization and prevents some weird import mess so we do not
+// have to alias packages.
+type Set struct {
+	*collector.Set
+}
+
+func NewSet(config SetConfig) (*Set, error) {
+	var err error
+
+	var opsgenieClient *opsgenie.Client
+	{
+		c := opsgenie.Config{
+			Key: config.Viper.GetString(config.Flag.Service.Opsgenie.API.Token),
+		}
+
+		opsgenieClient, err = opsgenie.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var alertCollector collector.Interface
+	{
+		c := alert.Config{
+			Client: opsgenieClient,
+		}
+
+		alertCollector, err = alert.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var collectorSet *collector.Set
+	{
+		c := collector.SetConfig{
+			Collectors: []collector.Interface{
+				alertCollector,
+			},
+			Logger: config.Logger,
+		}
+
+		collectorSet, err = collector.NewSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	s := &Set{
+		Set: collectorSet,
+	}
+
+	return s, nil
+}

--- a/service/error.go
+++ b/service/error.go
@@ -1,0 +1,14 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/giantswarm/microendpoint/service/version"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/viper"
+
+	"github.com/giantswarm/opsgenie-exporter/flag"
+	"github.com/giantswarm/opsgenie-exporter/service/collector"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	Description string
+	Flag        *flag.Flag
+	GitCommit   string
+	ProjectName string
+	Source      string
+	Viper       *viper.Viper
+}
+
+type Service struct {
+	Version *version.Service
+
+	bootOnce          sync.Once
+	exporterCollector *collector.Set
+}
+
+func New(config Config) (*Service, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.Flag == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Flag must not be empty", config)
+	}
+	if config.Viper == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Viper must not be empty", config)
+	}
+
+	var err error
+
+	var exporterCollector *collector.Set
+	{
+		c := collector.SetConfig{
+			Flag:   config.Flag,
+			Logger: config.Logger,
+			Viper:  config.Viper,
+		}
+
+		exporterCollector, err = collector.NewSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var versionService *version.Service
+	{
+		c := version.Config{
+			Description: config.Description,
+			GitCommit:   config.GitCommit,
+			Name:        config.ProjectName,
+			Source:      config.Source,
+		}
+
+		versionService, err = version.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	s := &Service{
+		Version: versionService,
+
+		bootOnce:          sync.Once{},
+		exporterCollector: exporterCollector,
+	}
+
+	return s, nil
+}
+
+func (s *Service) Boot(ctx context.Context) {
+	s.bootOnce.Do(func() {
+		go s.exporterCollector.Boot(ctx)
+	})
+}


### PR DESCRIPTION
Towards KPI Monitoring.

Added service package (not used yet) to better structure the project.

This was mostly copied from [github-exporter/service](https://github.com/giantswarm/github-exporter/tree/master/service) package.

`service/collector/alert/` was copied from `alert`, diff is here
```diff
Only in opsgenie: error.go
diff -r opsgenie/opsgenie.go ../../opsgenie/opsgenie.go
22c22
<               return nil, microerror.Maskf(invalidConfigError, "%T.Key must not be empty", config)
---
>               // TODO: Error.
collector $ diff -r alert/ ../../alert
diff -r alert/alert.go ../../alert/alert.go
5c5
<       "github.com/giantswarm/opsgenie-exporter/service/collector/opsgenie"
---
>       "github.com/giantswarm/opsgenie-exporter/opsgenie"
38c38
<               return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
---
>               // TODO: Error.
Only in alert/: error.go
```

`service/collector/opsgenie/` was copied from `opsgenie`, diff is here
```diff
Only in opsgenie: error.go
diff -r opsgenie/opsgenie.go ../../opsgenie/opsgenie.go
22c22
<               return nil, microerror.Maskf(invalidConfigError, "%T.Key must not be empty", config)
---
>               // TODO: Error.
```